### PR TITLE
use same client when executing queries in loop

### DIFF
--- a/graphql/resolvers/uploadTracker.ts
+++ b/graphql/resolvers/uploadTracker.ts
@@ -17,17 +17,19 @@ class UploadTrackerResolver {
     const {
       user: { id: user },
     } = await getServerSession(req, res, authOptions)
-    const insertRows: Promise<UploadTrackerResponse> = Promise.all(
-      data.map(async (item: TrackerInput, idx: number) => {
-        const { overview, numberCreativeHours, rating } = item
-        const today = new Date()
-        today.setDate(today.getDate() - (idx + 1))
-        const createdAt = `${today.getFullYear()}-${
-          today.getMonth() + 1
-        }-${today.getDate()}`
-        return await pool
-          .query(
-            `INSERT INTO tracker (
+
+    return await pool.connect().then((client: typeof pool) => {
+      const insertRows: Promise<UploadTrackerResponse> = Promise.all(
+        data.map(async (item: TrackerInput, idx: number) => {
+          const { overview, numberCreativeHours, rating } = item
+          const today = new Date()
+          today.setDate(today.getDate() - (idx + 1))
+          const createdAt = `${today.getFullYear()}-${
+            today.getMonth() + 1
+          }-${today.getDate()}`
+          return await client
+            .query(
+              `INSERT INTO tracker (
                 overview, 
                 number_creative_hours, 
                 rating, 
@@ -41,47 +43,47 @@ class UploadTrackerResolver {
                 TO_TIMESTAMP($4, 'YYYY-MM-DD'),
                 $5
               );`,
-            [overview, numberCreativeHours, rating, createdAt, user]
-          )
-          .catch((e: PgQueryError) => {
-            if (e.code === "23503") {
-              const details = postgresErrorDetails(e.detail)
-              // code:
-              // detail: 'Key (user)=(1) is not present in table "user".'
-              return {
-                errors: [
-                  {
-                    field: details[1],
-                    message: `id ${details[3] + details[4]}`,
-                  },
-                ],
+              [overview, numberCreativeHours, rating, createdAt, user]
+            )
+            .catch((e: PgQueryError) => {
+              if (e.code === "23503") {
+                const details = postgresErrorDetails(e.detail)
+                // code:
+                // detail: 'Key (user)=(1) is not present in table "user".'
+                return {
+                  errors: [
+                    {
+                      field: details[1],
+                      message: `id ${details[3] + details[4]}`,
+                    },
+                  ],
+                }
               }
-            }
-            console.log(e)
-            return {
-              errors: [{ field: "unknown", massage: "unhandled error" }],
-            }
-          })
-      })
-    )
-      .then(() => {
-        return {
-          uploaded: `successfully uploaded ${data.length} days worth of data`,
-        }
-      })
-      .catch((e) => {
-        console.log(e)
-        return {
-          errors: [
-            {
-              field: "unknown",
-              message: `something went wrong. check the database logs`,
-            },
-          ],
-        }
-      })
-
-    return insertRows
+              console.log(e)
+              return {
+                errors: [{ field: "unknown", massage: "unhandled error" }],
+              }
+            })
+        })
+      )
+        .then(() => {
+          return {
+            uploaded: `successfully uploaded ${data.length} days worth of data`,
+          }
+        })
+        .catch((e) => {
+          console.log(e)
+          return {
+            errors: [
+              {
+                field: "unknown",
+                message: `something went wrong. check the database logs`,
+              },
+            ],
+          }
+        })
+      return insertRows
+    })
   }
 }
 

--- a/utils/postgres.ts
+++ b/utils/postgres.ts
@@ -3,7 +3,7 @@ import pkg from "pg"
 delete pkg.native
 const { Pool } = pkg
 
-export const pool = new Pool({
+export const pool: typeof Pool = new Pool({
   user: keys.pgUser,
   host: keys.serverHost,
   database: keys.pgDatabase,


### PR DESCRIPTION
@ChrisShep98 I think this might fix some of our infrastructure problems with the database. the container was crashing on the prod server when using the upload function, so that could have been due to using a different client from the pool for each query in the loop. there were no connection failure logs when I tested the upload function locally with these changes. the container has much more ram in my local environment, so that could be another reason it doesn't crash locally. if this doesn't fix the prod environment we'll probably have to allocate more ram to the pg container in the prod environment. still, these changes are a better practice when executing many queries in a loop